### PR TITLE
fix: solve the id conflict with yxl.cloudmusic

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "views": {
       "treeView": [
         {
-          "id": "local",
+          "id": "z-reader-local",
           "name": "目录"
         }
       ]
@@ -78,35 +78,35 @@
       "view/title": [
         {
           "command": "z-reader.command.refresh",
-          "when": "view == local",
+          "when": "view == z-reader-local",
           "group": "navigation"
         },
         {
           "command": "z-reader.command.searchOnline",
-          "when": "view == local",
+          "when": "view == z-reader-local",
           "group": "navigation"
         },
         {
           "command": "z-reader.command.openLocalDirectory",
-          "when": "view == local"
+          "when": "view == z-reader-local"
         },
         {
           "command": "z-reader.command.setOnlineSite",
-          "when": "view == local"
+          "when": "view == z-reader-local"
         },
         {
           "command": "z-reader.command.setEncoding",
-          "when": "view == local"
+          "when": "view == z-reader-local"
         }
       ],
       "view/item/context": [
         {
           "command": "z-reader.command.openLocalDirectory",
-          "when": "view == local"
+          "when": "view == z-reader-local"
         },
         {
           "command": "z-reader.command.setOnlineSite",
-          "when": "view == local"
+          "when": "view == z-reader-local"
         }
       ]
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,4 +25,4 @@ export const TemplatePath = {
   templateHtml: path.join('static', 'template', 'default', 'index.html')
 };
 
-export const TREEVIEW_ID = 'local';
+export const TREEVIEW_ID = 'z-reader-local';


### PR DESCRIPTION
解决与插件yxl.cloudmusic使用了相同treeViewId导致的冲突问题，建议treeViewId使用"插件名称+treeViewName"形式来避免冲突 #40 